### PR TITLE
Add support for reading lag error cyclically

### DIFF
--- a/ANSIC.lby
+++ b/ANSIC.lby
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?AutomationStudio FileVersion="4.9"?>
-<Library Version="4.01.1" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
+<Library Version="4.02.0" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
   <Files>
     <File>AxisLib.html</File>
     <File>AxisLib.md</File>

--- a/AxisBasicCyclic.c
+++ b/AxisBasicCyclic.c
@@ -176,6 +176,21 @@ plcbit AxisBasicCyclic(struct AxisBasic_Api_typ* Api, struct AxisBasic_IN_CFG_ty
 
 	MC_WriteParameter(&internal->FUB.WriteParameter);
 	
+	
+	// Cyclic reads. 
+	internal->CyclicReadPar.ParID = 112; // PCTRL_LAG_ERROR;
+	internal->CyclicReadPar.DataType = mcACPAX_PARTYPE_REAL;
+	internal->CyclicReadPar.VariableAddress = &Api->OUT.Lag;
+	internal->CyclicReadPar.RefreshMode = mcACPAX_CYCLIC_EVERY_RECORD;
+	
+	internal->FUB.CyclicRead.Axis = Api->pAxisObject;
+	internal->FUB.CyclicRead.Enable = !configuration->DisableLagRead;
+	internal->FUB.CyclicRead.DataAddress = &internal->CyclicReadPar;
+	internal->FUB.CyclicRead.Mode = mcACPAX_CYCLIC_PARID_READ;
+	internal->FUB.CyclicRead.NumberOfParIDs = 1;
+	
+	MC_BR_CyclicProcessParID_AcpAx(&internal->FUB.CyclicRead);
+	
 
 	// Busy 
 	Api->OUT.Busy = internal->FUB.Reference.Busy

--- a/Types.typ
+++ b/Types.typ
@@ -135,6 +135,7 @@ TYPE
 		HomingMode : McHomingModeEnum;
 		DefaultPosition : LREAL;
 		StopDeceleration : REAL := 10000.0; (*Deceleration for stopping.*)
+		DisableLagRead : BOOL;
 	END_STRUCT;
 	AxisBasic_OUT_typ : 	STRUCT  (*Axis manager outputs (read only).*)
 		Name : STRING[AXLIB_STRLEN_NAME];
@@ -147,6 +148,7 @@ TYPE
 		Warning : BOOL; (*Axis warning is present.*)
 		Position : LREAL; (*Actual position of the axis [Units].*)
 		Velocity : REAL; (*Actual velocity of the axis [Units/s].*)
+		Lag : REAL;
 		State : AxisLib_AxisState_typ;
 		PLCOpen : McAxisPLCopenStateEnum; (*Extended PLCopen state*)
 		PLCOpenDiscrete : AxisLib_PLCOpenState_typ;
@@ -175,6 +177,7 @@ TYPE
 		FUB : AxisBasic_Int_FUB_typ;
 		ResetOK : BOOL; (*It is OK to call MC_Reset. Necessary because of timing between Errorstop state and error reporting.*)
 		FubError : BOOL;
+		CyclicReadPar : McAcpAxCycParIDType;
 	END_STRUCT;
 	AxisBasic_Int_FUB_typ : 	STRUCT 
 		Status : AxisStatus;
@@ -191,6 +194,7 @@ TYPE
 		ReadAxisError : MC_ReadAxisError;
 		Reset : MC_Reset;
 		WriteParameter : MC_WriteParameter;
+		CyclicRead : MC_BR_CyclicProcessParID_AcpAx;
 	END_STRUCT;
 	AxisBasic_Api_typ : 	STRUCT 
 		pAxisObject : REFERENCE TO McAxisType; (*Pointer to the axis object (global variable from mapp configuration).*)

--- a/VersionHistory.txt
+++ b/VersionHistory.txt
@@ -1,3 +1,5 @@
+4.2.0 - Add support for cylically reading the lag error (enabled by default)
+
 4.1.1 - Add explicit ranges to the MappMotion dependencies
 
 4.1.0 - Add support for enabling/disabling SW limits


### PR DESCRIPTION
Lag error is dumped into the gMotorBasic.OUT structure. Enabled by default, it can be disabled via Configuration.csv. 